### PR TITLE
src: use node-addon-api instead of nan

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,13 @@
         "linux-perf.cc",
         "linux-perf-listener.cc",
       ],
-      "include_dirs": ["<!(node -e \"require('nan')\")"],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').gyp\")"
+      ],
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
     }
   ]
 }

--- a/linux-perf-listener.cc
+++ b/linux-perf-listener.cc
@@ -1,4 +1,5 @@
 #include <sstream>
+#include <uv.h>
 
 #include "linux-perf.h"
 

--- a/linux-perf.h
+++ b/linux-perf.h
@@ -2,8 +2,7 @@
 #define __LINUX_PERF_H
 
 #include "v8-profiler.h"
-#include <nan.h>
-#include <node_object_wrap.h>
+#include <napi.h>
 #include <fstream>
 
 
@@ -21,18 +20,17 @@ class LinuxPerfHandler : public v8::CodeEventHandler {
   std::string FormatName(v8::CodeEvent* code_event);
 };
 
-class LinuxPerf : public Nan::ObjectWrap {
+class LinuxPerf : public Napi::ObjectWrap<LinuxPerf> {
  public:
-  static void Initialize(v8::Local<v8::Object> target);
+  explicit LinuxPerf(const Napi::CallbackInfo& info);
+  ~LinuxPerf();
 
-  static NAN_METHOD(New);
-  static NAN_METHOD(Start);
-  static NAN_METHOD(Stop);
+  static void Initialize(Napi::Env env, Napi::Object exports);
+
+  Napi::Value Start(const Napi::CallbackInfo& info);
+  Napi::Value Stop(const Napi::CallbackInfo& info);
 
   LinuxPerfHandler* handler;
-
-  LinuxPerf() = default;
-  ~LinuxPerf() = default;
 };
 
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mmarchini/node-linux-perf#readme",
   "dependencies": {
-    "nan": "^2.10.0",
+    "node-addon-api": "^1.7.1",
     "node-gyp": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Although there are `v8.h` and `uv.h` in the code, I still think that using `node-addon-api` instead of `nan` would be a good idea as `node-linux-perf` doesn't need and couldn't support Node.js 8 which might have insufficient napi support (if I have understood correctly). 

I don't need to compile again on Node.js 12 for a build from Node.js 10 with `node-addon-api` on my Mac.